### PR TITLE
Upgrade set_dri_name script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 __pycache__/
 *.pyc
+
+# IDEs
+.vscode

--- a/Launchers/rescue_people/launch.py
+++ b/Launchers/rescue_people/launch.py
@@ -6,8 +6,10 @@ import os
 from subprocess import Popen, PIPE
 
 
-# If DRI_NAME is not set by user, use card0
-DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
+# If DRI_NAME is not set, set DRI_PATH to None
+DRI_NAME = os.environ.get("DRI_NAME")
+DRI_PATH = os.path.join("/dev/dri", DRI_NAME) if DRI_NAME else None
+
 EXERCISE = "rescue_people_newmanager"
 TIMEOUT = 30
 MAX_ATTEMPT = 2

--- a/scripts/set_dri_name.sh
+++ b/scripts/set_dri_name.sh
@@ -3,7 +3,7 @@
 # Function to get the GPU device path based on vendor priority
 get_gpu_device() {
     preferred_vendor=$1
-    # Default vendor priority: NVIDIA > Intel > others
+    # Default vendor priority: NVIDIA > Intel
     priority=(nvidia intel)
 
     # If a preferred vendor is provided, prioritize it
@@ -13,6 +13,8 @@ get_gpu_device() {
 
     # Get GPU information
     gpu_list=$(lspci -nn | grep VGA)
+    echo "GPUs found:"
+    echo $gpu_list | sed 's/^/\t/'
 
     for vendor in "${priority[@]}"; do
         if [[ "$vendor" == "nvidia" ]]; then
@@ -33,8 +35,10 @@ get_gpu_device() {
                 export DRI_NAME="$device"
                 export DRI_VENDOR="$vendor"
                 # Echo the selected vendor and DRI_NAME
-                echo "DRI_VENDOR: $DRI_VENDOR"
-                echo "DRI_NAME: $DRI_NAME"
+                echo "GPU selected:"
+                echo -e "\t$gpu_info"
+                echo -e "\tDRI_VENDOR: $DRI_VENDOR"
+                echo -e "\tDRI_NAME: $DRI_NAME"
                 return 0
             fi
         fi
@@ -42,10 +46,11 @@ get_gpu_device() {
 
 
     if [ -n "$preferred_vendor" ]; then
-        echo "Error: No GPU found for the vendor '$preferred_vendor'." >&2
+        echo "Warning: No GPU found for requested vendor '$preferred_vendor'"
     else
-        echo "Error: No GPU found" >&2
+        echo "Warning: No GPU found for valid vendors: '${priority[@]}'"
     fi
+    echo "Falling back to CPU-only mode"
 
     return 1
 }
@@ -54,4 +59,6 @@ get_gpu_device() {
 preferred_vendor="${1,,}"  # Convert to lowercase
 
 # Get the GPU device path based on priority and set DRI_NAME
+echo -e "\n--- set_dri_name.sh ---"
 get_gpu_device "$preferred_vendor"
+echo -e "-----------------------\n"


### PR DESCRIPTION
Changes:
- Much more verbose
- Checks if device path exists before setting the variables (`lspci` always finds all host GPUs but they may not be accessible in `/dev/dri`)
- In `Launchers/rescue_people/launch.py`, avoid setting `card0` blindly when `DRI_NAME` is not defined

It's worth mentioning that, unless a different vendor is specified as argument when launching the script, only Nvidia and Intel GPUs are considered.

Here are the outputs for each possible combination of `--gpus all` and `--device /dev/dri` flags in a host PC with a dual GPU configuration (Nvidia and Intel):

```
$ docker run --rm -it --gpus all --device /dev/dri -p 7164:7164 -p 6080:6080 -p 1108:1108 -p 7163:7163 --entrypoint /bin/bash jderobot/robotics-backend
root@9b1a29fd764b:/# source set_dri_name.sh 

--- GPU acceleration info ---
GPUs found:
        00:02.0 VGA compatible controller [0300]: Intel Corporation HD Graphics 630 [8086:591b] (rev 04)
        01:00.0 VGA compatible controller [0300]: NVIDIA Corporation GP107M [GeForce GTX 1050 Mobile] [10de:1c8d] (rev a1)
GPU selected:
        01:00.0 VGA compatible controller [0300]: NVIDIA Corporation GP107M [GeForce GTX 1050 Mobile] [10de:1c8d] (rev a1)
        DRI_VENDOR: nvidia
        DRI_NAME: card1
-----------------------------
```
```
$ docker run --rm -it --device /dev/dri -p 7164:7164 -p 6080:6080 -p 1108:1108 -p 716:7163 --entrypoint /bin/bash jderobot/robotics-backend
root@9a784e45f282:/# source set_dri_name.sh 

--- GPU acceleration info ---
GPUs found:
        00:02.0 VGA compatible controller [0300]: Intel Corporation HD Graphics 630 [8086:591b] (rev 04)
        01:00.0 VGA compatible controller [0300]: NVIDIA Corporation GP107M [GeForce GTX 1050 Mobile] [10de:1c8d] (rev a1)
Warning: nvidia-smi not available or failed, skipping NVIDIA GPU.
GPU selected:
        00:02.0 VGA compatible controller [0300]: Intel Corporation HD Graphics 630 [8086:591b] (rev 04)
        DRI_VENDOR: intel
        DRI_NAME: card0
-----------------------------
```
```
$ docker run --rm -it  --gpus all -p 7164:7164 -p 6080:6080 -p 1108:1108 -p 7163:7163 --entrypoint /bin/bash jderobot/robotics-backend
root@47b326a62434:/# source set_dri_name.sh 

--- GPU acceleration info ---
GPUs found:
        00:02.0 VGA compatible controller [0300]: Intel Corporation HD Graphics 630 [8086:591b] (rev 04)
        01:00.0 VGA compatible controller [0300]: NVIDIA Corporation GP107M [GeForce GTX 1050 Mobile] [10de:1c8d] (rev a1)
Warning: Skipping /dev/dri/card1 does not exist.
Warning: Skipping /dev/dri/card0 does not exist.
Warning: No GPU found for valid vendors: 'nvidia intel'
Falling back to CPU-only mode
-----------------------------	
```
```
$ docker run --rm -it -p 7164:7164 -p 6080:6080 -p 1108:1108 -p 7163:7163 --entrypoint /bin/bash jderobot/robotics-backend
root@93d8fbc6bf96:/# source set_dri_name.sh 

--- GPU acceleration info ---
GPUs found:
        00:02.0 VGA compatible controller [0300]: Intel Corporation HD Graphics 630 [8086:591b] (rev 04)
        01:00.0 VGA compatible controller [0300]: NVIDIA Corporation GP107M [GeForce GTX 1050 Mobile] [10de:1c8d] (rev a1)
Warning: nvidia-smi not available or failed, skipping NVIDIA GPU.
Warning: Skipping /dev/dri/card0 does not exist.
Warning: No GPU found for valid vendors: 'nvidia intel'
Falling back to CPU-only mode
-----------------------------
```