### PR TITLE
Fix car x orientation in global navigation (#607)

### DIFF
--- a/CustomRobots/taxi_navigator/models/taxi_holo_ROS_harmonic/model.sdf
+++ b/CustomRobots/taxi_navigator/models/taxi_holo_ROS_harmonic/model.sdf
@@ -17,7 +17,7 @@
 
       <!-- collision & visual both use the same mesh -->
       <collision name="collision">
-        <pose>0 0 0 1.57 0 0 </pose>
+        <pose>0 0 0 0 0 1.57 </pose>
         <geometry>
           <mesh>
             <uri>model://taxi_holo_ROS_harmonic/meshes/taxi_holo.obj</uri>
@@ -25,7 +25,7 @@
         </geometry>
       </collision>
       <visual name="visual">
-        <pose>0 0 0 1.57 0 0 </pose>
+        <pose>0 0 0 0 0 1.57 </pose>
         <geometry>
           <mesh>
             <uri>model://taxi_holo_ROS_harmonic/meshes/taxi_holo.obj</uri>


### PR DESCRIPTION
Fixes #607
Changed roll from 1.57 to 0 and yaw from 0 to 1.57 in model.sdf to fix the car flipping instead of rotating properly.