### PR TITLE
sim: reduce wheel friction for Ackermann logistic robot

### DIFF
--- a/CustomRobots/ackermann_logistic_robot/models/ackermann_logistic_robot/model.sdf
+++ b/CustomRobots/ackermann_logistic_robot/models/ackermann_logistic_robot/model.sdf
@@ -100,8 +100,8 @@
           </contact>
           <friction>
             <ode>
-              <mu>1e+6</mu>
-              <mu2>1e+6</mu2>
+              <mu>1.5</mu>
+              <mu2>1.5</mu2>
             </ode>
           </friction>
         </surface>
@@ -159,8 +159,8 @@
           </contact>
           <friction>
             <ode>
-              <mu>1e+6</mu>
-              <mu2>1e+6</mu2>
+              <mu>1.5</mu>
+              <mu2>1.5</mu2>
             </ode>
           </friction>
         </surface>
@@ -251,8 +251,8 @@
           </contact>
           <friction>
             <ode>
-              <mu>1e+6</mu>
-              <mu2>1e+6</mu2>
+              <mu>1.5</mu>
+              <mu2>1.5</mu2>
             </ode>
           </friction>
         </surface>
@@ -344,8 +344,8 @@
           </contact>
           <friction>
             <ode>
-              <mu>1e+6</mu>
-              <mu2>1e+6</mu2>
+              <mu>1.5</mu>
+              <mu2>1.5</mu2>
             </ode>
           </friction>
         </surface>


### PR DESCRIPTION
**<--Summary-->**
This PR reduces excessively high wheel friction values in the Ackermann logistic
robot Gazebo model to improve steering realism and simulation stability.

**< Changes>**
- Replaced extreme friction values (`1e+6`) with realistic values (`1.5`)
- Updated all wheel collision elements in the Gazebo SDF model
- No changes to URDF, meshes, or controllers

> **Note: "model.sdf" is normally ignored by ".gitignore", but is force-added here**
> as required to adjust Gazebo wheel friction per issue #362.

### Related Issue
Closes #362
