### PR TITLE
Fix Spa Circuit ROS–Gazebo bridge configuration

### DIFF
--- a/CustomRobots/f1/params/f1_renault_ackermann_harmonic_laser.yaml
+++ b/CustomRobots/f1/params/f1_renault_ackermann_harmonic_laser.yaml
@@ -1,0 +1,20 @@
+# gz topic published by AckermannSteering plugin
+- ros_topic_name: "odom"
+  gz_topic_name: "/model/f1_renault_ackermann_harmonic_laser/odom"
+  ros_type_name: "nav_msgs/msg/Odometry"
+  gz_type_name: "gz.msgs.Odometry"
+  direction: GZ_TO_ROS
+
+# gz topic subscribed to by AckermannSteering plugin
+- ros_topic_name: "cmd_vel"
+  gz_topic_name: "/model/f1_renault_ackermann_harmonic_laser/cmd_vel"
+  ros_type_name: "geometry_msgs/msg/Twist"
+  gz_type_name: "gz.msgs.Twist"
+  direction: ROS_TO_GZ
+
+# gz topic published by Sensors plugin (Camera)
+- ros_topic_name: "/cam_f1_left/camera_info"
+  gz_topic_name: "/cam_f1_left/camera_info"
+  ros_type_name: "sensor_msgs/msg/CameraInfo"
+  gz_type_name: "gz.msgs.CameraInfo"
+  direction: GZ_TO_ROS

--- a/Launchers/spa_circuit/spawn_robot.launch.py
+++ b/Launchers/spa_circuit/spawn_robot.launch.py
@@ -80,7 +80,7 @@ def generate_launch_description():
     start_gazebo_ros_image_bridge_cmd = Node(
         package="ros_gz_image",
         executable="image_bridge",
-        arguments=["/model/f1_renault_ackermann_harmonic_laser/camera/image_raw"],
+        arguments=["/cam_f1_left/image_raw"],
         output="screen",
     )
 


### PR DESCRIPTION
While testing the **Spa Circuit** exercise, I noticed that ROS–Gazebo bridging is broken in a way that’s easy to miss.

The Spa Circuit launcher references a bridge params file that doesn’t exist, so the `ros_gz_bridge` node fails to start. On top of that, the image bridge subscribes to a camera topic the model never publishes. Gazebo loads and renders fine, but no ROS topics (`cmd_vel`, `odom`, camera) are actually bridged, so student code receives no data and can’t control the car.

All other F1 circuits have this wired up correctly, so Spa Circuit behaves inconsistently.

This PR:

* Adds the missing bridge params file for `f1_renault_ackermann_harmonic_laser`
* Fixes the camera image topic to match the model and the other F1 circuits

Small, focused fix, no refactors — just brings Spa Circuit back in line with the rest.

---