### PR TITLE
Fixing The labyrinth escape design 

### DIFF
--- a/CustomRobots/drone_assets/worlds/labyrinth_escape_harmonic.world
+++ b/CustomRobots/drone_assets/worlds/labyrinth_escape_harmonic.world
@@ -73,7 +73,7 @@
 		<include>
 			<uri>model://arrow</uri>
 			<name>arrow_6</name>
-			<pose>2.5 14.5 0.1 0 0 4.71</pose>
+			<pose>2.5 14.5 0.1 0 0 0</pose>
 		</include>
 		<include>
 			<uri>model://arrow</uri>

--- a/CustomRobots/drone_assets/worlds/labyrinth_escape_harmonic.world
+++ b/CustomRobots/drone_assets/worlds/labyrinth_escape_harmonic.world
@@ -73,7 +73,7 @@
 		<include>
 			<uri>model://arrow</uri>
 			<name>arrow_6</name>
-			<pose>2.5 14.5 0.1 0 0 3.14</pose>
+			<pose>2.5 14.5 0.1 0 0 4.71</pose>
 		</include>
 		<include>
 			<uri>model://arrow</uri>

--- a/CustomRobots/drone_assets/worlds/labyrinth_escape_harmonic.world
+++ b/CustomRobots/drone_assets/worlds/labyrinth_escape_harmonic.world
@@ -73,7 +73,7 @@
 		<include>
 			<uri>model://arrow</uri>
 			<name>arrow_6</name>
-			<pose>2.5 14.5 0.1 0 0 0</pose>
+			<pose>2.5 14.5 0.1 0 0 4.71</pose>
 		</include>
 		<include>
 			<uri>model://arrow</uri>


### PR DESCRIPTION
This pr is in regards with [issue 3462](https://github.com/JdeRobot/RoboticsAcademy/issues/3462) will fix the issue pertaining to the labyrinth escape design of the map.  
The arrow is pointing in the wrong direction 
<img width="1100" height="327" alt="Screenshot from 2026-02-23 22-42-26" src="https://github.com/user-attachments/assets/ae98a5ad-c2d4-4e6c-a9c4-018797d5a319" />

The correct  design should look like:
<img width="968" height="440" alt="Screenshot from 2026-03-01 13-39-19" src="https://github.com/user-attachments/assets/8d6467b9-00bc-4103-8e76-d7b9f51c8504" />
