### PR TITLE
f1: namespace the car by entity so N of them can run together

### DIFF
--- a/CustomRobots/f1/launch/f1.launch.py
+++ b/CustomRobots/f1/launch/f1.launch.py
@@ -1,50 +1,67 @@
 import os
+import re
+import tempfile
+
 import xacro
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.substitutions import LaunchConfiguration, Command, IfElseSubstitution
+from launch.substitutions import LaunchConfiguration
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch_ros.actions import Node
-from launch_ros.parameter_descriptions import ParameterValue
+
+
+def _render_bridge(package_dir, namespace):
+    """Render a per-namespace copy of the bridge yaml.
+
+    The stock f1_renault.yaml uses fixed gz topics (F1ROS/odom, /F1ROS/cmd_vel,
+    f1/laser/scan, /cam_f1_left/...). For N cars each model namespaces its plugin
+    topics under its entity name, so the bridge must point at /<namespace>/...
+    too. Copy the yaml and prefix every topic name with the namespace.
+    """
+    src = os.path.join(package_dir, "params", "f1_renault.yaml")
+    with open(src) as f:
+        text = f.read()
+
+    def _prefix(match):
+        key, quote, topic = match.group(1), match.group(2), match.group(3)
+        return f"{key}: {quote}/{namespace}/{topic.lstrip('/')}{quote}"
+
+    text = re.sub(
+        r'(ros_topic_name|gz_topic_name):\s*(["\'])(.*?)\2',
+        _prefix,
+        text,
+    )
+
+    out = os.path.join(tempfile.gettempdir(), f"f1_bridge_{namespace}.yaml")
+    with open(out, "w") as f:
+        f.write(text)
+    return out
 
 
 def launch_setup(context):
-    use_sim_time = LaunchConfiguration("use_sim_time")
     x = LaunchConfiguration("x")
     y = LaunchConfiguration("y")
     z = LaunchConfiguration("z")
     R = LaunchConfiguration("R")
     P = LaunchConfiguration("P")
     Y = LaunchConfiguration("Y")
-    sensor = LaunchConfiguration("sensor")
-    mode = LaunchConfiguration("mode")
+    sensor = LaunchConfiguration("sensor").perform(context)
+    mode = LaunchConfiguration("mode").perform(context)
+    # entity name from RAM, used as the ROS/gz namespace so N cars don't
+    # collide. defaults to "f1" so a single-car launch behaves as before.
+    namespace = LaunchConfiguration("entity").perform(context) or "f1"
 
     package_dir = get_package_share_directory("custom_robots")
-
     nodes_to_start = []
 
-    f1_sensor = "camera"
-    f1_model = "holonomic"
+    f1_sensor = "laser" if sensor == "laser" else "camera"
+    f1_model = "ackermann" if mode == "ackermann" else "holonomic"
 
-    if sensor.perform(context) == "laser":
-        f1_sensor = "laser"
+    bridge_yaml = _render_bridge(package_dir, namespace)
 
-    if mode.perform(context) == "ackermann":
-        f1_model = "ackermann"
-
-    bridge_yaml = os.path.join(package_dir, "params", "f1_renault.yaml")
-
-    # =========================
-    # ROBOT DESCRIPTION (URDF)
-    # =========================
-    xacro_file = os.path.join(
-        package_dir,
-        "models",
-        "f1",
-        "f1.urdf.xacro",
-    )
-
+    # robot description (URDF) with plugin topics namespaced under the entity
+    xacro_file = os.path.join(package_dir, "models", "f1", "f1.urdf.xacro")
     robot_description_content = xacro.process_file(
         xacro_file,
         mappings={
@@ -52,15 +69,18 @@ def launch_setup(context):
             "ackermann": "true" if f1_model == "ackermann" else "false",
             "camera": "true" if f1_sensor == "camera" else "false",
             "laser": "true" if f1_sensor == "laser" else "false",
+            "namespace": namespace,
         },
     ).toxml()
-
     robot_description = {"robot_description": robot_description_content}
 
+    # all nodes run inside the entity's namespace so two cars never share node
+    # names or topics (robot_state_publisher, /robot_description, the bridges).
     robot_state_publisher_node = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
         name="robot_state_publisher",
+        namespace=namespace,
         output="screen",
         parameters=[robot_description, {"use_sim_time": True}],
     )
@@ -69,24 +89,10 @@ def launch_setup(context):
         package="ros_gz_sim",
         executable="create",
         arguments=[
-            "-topic",
-            "/robot_description",
-            "-name",
-            "f1",
-            "-allow_renaming",
-            "true",
-            "-x",
-            x,
-            "-y",
-            y,
-            "-z",
-            z,
-            "-R",
-            R,
-            "-P",
-            P,
-            "-Y",
-            Y,
+            "-topic", f"/{namespace}/robot_description",
+            "-name", namespace,
+            "-allow_renaming", "true",
+            "-x", x, "-y", y, "-z", z, "-R", R, "-P", P, "-Y", Y,
         ],
         output="screen",
     )
@@ -94,20 +100,19 @@ def launch_setup(context):
     gz_ros2_bridge = Node(
         package="ros_gz_bridge",
         executable="parameter_bridge",
+        namespace=namespace,
         arguments=["--ros-args", "-p", f"config_file:={bridge_yaml}"],
         output="screen",
     )
 
-    nodes_to_start.append(robot_state_publisher_node)
-    nodes_to_start.append(gz_spawn_entity)
-    nodes_to_start.append(gz_ros2_bridge)
+    nodes_to_start += [robot_state_publisher_node, gz_spawn_entity, gz_ros2_bridge]
 
-    # Sensor deppending on sensor arguments
     if f1_sensor == "camera":
         gz_ros2_image_bridge = Node(
             package="ros_gz_image",
             executable="image_bridge",
-            arguments=["/cam_f1_left/image_raw"],
+            namespace=namespace,
+            arguments=[f"/{namespace}/cam_f1_left/image_raw"],
             output="screen",
         )
         nodes_to_start.append(gz_ros2_image_bridge)
@@ -116,21 +121,19 @@ def launch_setup(context):
 
 
 def generate_launch_description():
-    declared_arguments = []
-
-    # Add any entry parameter
-    declared_arguments.append(
-        DeclareLaunchArgument("use_sim_time", default_value="true")
-    )
-    declared_arguments.append(DeclareLaunchArgument("x", default_value="0"))
-    declared_arguments.append(DeclareLaunchArgument("y", default_value="0"))
-    declared_arguments.append(DeclareLaunchArgument("z", default_value="0"))
-    declared_arguments.append(DeclareLaunchArgument("R", default_value="0"))
-    declared_arguments.append(DeclareLaunchArgument("P", default_value="0"))
-    declared_arguments.append(DeclareLaunchArgument("Y", default_value="0"))
-    declared_arguments.append(DeclareLaunchArgument("sensor", default_value="camera"))
-    declared_arguments.append(DeclareLaunchArgument("mode", default_value="holo"))
-
+    declared_arguments = [
+        DeclareLaunchArgument("use_sim_time", default_value="true"),
+        DeclareLaunchArgument("x", default_value="0"),
+        DeclareLaunchArgument("y", default_value="0"),
+        DeclareLaunchArgument("z", default_value="0"),
+        DeclareLaunchArgument("R", default_value="0"),
+        DeclareLaunchArgument("P", default_value="0"),
+        DeclareLaunchArgument("Y", default_value="0"),
+        DeclareLaunchArgument("sensor", default_value="camera"),
+        DeclareLaunchArgument("mode", default_value="holo"),
+        # entity/namespace for this car; RAM passes the unique entity (e.g. f1_0)
+        DeclareLaunchArgument("entity", default_value="f1"),
+    ]
     return LaunchDescription(
         declared_arguments + [OpaqueFunction(function=launch_setup)]
     )

--- a/CustomRobots/f1/models/f1/f1.urdf.xacro
+++ b/CustomRobots/f1/models/f1/f1.urdf.xacro
@@ -6,6 +6,8 @@
   <xacro:arg name="ackermann" default="false"/>
   <xacro:arg name="camera" default="true"/>
   <xacro:arg name="laser" default="false"/>
+  <!-- entity name = ROS/gz namespace, so N cars don't share topics -->
+  <xacro:arg name="namespace" default="f1"/>
 
   <xacro:include filename="$(find custom_robots)/models/f1/f1_gz.urdf.xacro"/>
   <xacro:include filename="$(find custom_robots)/models/f1/f1_common.urdf.xacro"/>

--- a/CustomRobots/f1/models/f1/f1_common.urdf.xacro
+++ b/CustomRobots/f1/models/f1/f1_common.urdf.xacro
@@ -24,8 +24,8 @@
       </visual>
     </link>
 
-    <xacro:f1_velocity topic="/F1ROS/cmd_vel"/>
-    <xacro:f1_odom topic="/F1ROS/odom" freq="50"/>
+    <xacro:f1_velocity topic="/$(arg namespace)/F1ROS/cmd_vel"/>
+    <xacro:f1_odom topic="/$(arg namespace)/F1ROS/odom" freq="50"/>
   </xacro:macro>
 
   <xacro:macro name="ackermann">
@@ -216,9 +216,9 @@
       </visual>
     </link> -->
 
-    <xacro:f1_ackermann_steering topic="/F1ROS/cmd_vel"/>
+    <xacro:f1_ackermann_steering topic="/$(arg namespace)/F1ROS/cmd_vel"/>
     <xacro:f1_joints/>
-    <xacro:f1_odom topic="/F1ROS/odom" freq="50"/>
+    <xacro:f1_odom topic="/$(arg namespace)/F1ROS/odom" freq="50"/>
     <!-- <xacro:f1_steer_controller topic="/model/f1_renault_ackermann_harmonic/steering_wheel_cmd" joint="steering_joint"/> -->
   </xacro:macro>
 </robot>

--- a/CustomRobots/f1/models/f1/f1_gz.urdf.xacro
+++ b/CustomRobots/f1/models/f1/f1_gz.urdf.xacro
@@ -22,9 +22,9 @@
         <always_on>true</always_on>
         <visualize>true</visualize>
         <update_rate>20.000000</update_rate>
-        <topic>/${name}/image_raw</topic>
+        <topic>/$(arg namespace)/${name}/image_raw</topic>
         <camera name="cleft">
-          <camera_info_topic>/${name}/camera_info</camera_info_topic>
+          <camera_info_topic>/$(arg namespace)/${name}/camera_info</camera_info_topic>
           <horizontal_fov>1.570000</horizontal_fov>
           <image>
             <width>640</width>
@@ -65,7 +65,7 @@
         <always_on>1</always_on>
         <visualize>1</visualize>
         <update_rate>20</update_rate>
-        <topic>f1/laser/scan</topic>
+        <topic>/$(arg namespace)/f1/laser/scan</topic>
         <gz_frame_id>base_scan</gz_frame_id>
         <lidar>
           <scan>


### PR DESCRIPTION
## f1: namespace the car by entity so N of them can run together

lets the same robot be spawned more than once in one simulation. pairs with the
multi-robot support in RoboticsApplicationManager and RoboticsAcademy.

### what changed
the launch file takes a new `entity` argument (default `f1`, so a single-car
launch behaves exactly as before) and uses it as the ros/gazebo namespace:

- the xacro is rendered per car with a `namespace` mapping, so the model's plugin
  topics become `/<entity>/F1ROS/cmd_vel`, `/<entity>/F1ROS/odom`, the camera and
  the laser scan
- the bridge yaml is rendered per namespace too, since the stock one points at
  fixed gz topics
- `robot_state_publisher`, the gz bridge and the image bridge all run inside the
  namespace, and the car spawns as `-name <entity>` from `/<entity>/robot_description`

so two cars come up as `/f1_0/...` and `/f1_1/...` and never share a topic or a
node name. RAM passes the entity it generated for each robot.
