### PR TITLE
Fix drone gripper reattachment after reset

### DIFF
--- a/Industrial/drone_gripper/src/drone_gripper.cpp
+++ b/Industrial/drone_gripper/src/drone_gripper.cpp
@@ -176,12 +176,22 @@ void PreUpdate(
   {
     if (this->activeJoint != kNullEntity)
     {
-      _ecm.RequestRemoveEntity(this->activeJoint);
-      this->activeJoint = kNullEntity;
+      this->Detach(_ecm);
     }
     this->running_ = false;
     this->dead_ = true;
     return;
+  }
+
+  // Keep the old joint out of the attach path until ECM has processed its
+  // removal. Removing the component first gives the physics system an
+  // explicit one-time change to tear down the DART constraint before the
+  // joint entity is deleted.
+  if (this->pendingJoint != kNullEntity)
+  {
+    if (_ecm.HasEntity(this->pendingJoint))
+      return;
+    this->pendingJoint = kNullEntity;
   }
 
   // Drop the joint if the drone is gone OR is being removed this very cycle.
@@ -243,8 +253,7 @@ void Reset(
 {
   if (this->activeJoint != kNullEntity)
   {
-    _ecm.RequestRemoveEntity(this->activeJoint);
-    this->activeJoint = kNullEntity;
+    this->Detach(_ecm);
   }
   this->carriedModel = kNullEntity;
 
@@ -367,6 +376,9 @@ void TryAttach(EntityComponentManager &_ecm)
   if (bestChild == kNullEntity)
     return;
 
+  if (this->pendingJoint != kNullEntity)
+    return;
+
   const Entity jointEntity = _ecm.CreateEntity();
   components::DetachableJoint joint;
   joint.Data().parentLink = gripperLink;
@@ -384,6 +396,8 @@ void Detach(EntityComponentManager &_ecm)
   if (this->activeJoint == kNullEntity)
     return;
 
+  this->pendingJoint = this->activeJoint;
+  _ecm.RemoveComponent<components::DetachableJoint>(this->activeJoint);
   _ecm.RequestRemoveEntity(this->activeJoint);
   this->activeJoint = kNullEntity;
   this->carriedModel = kNullEntity;
@@ -409,6 +423,7 @@ double attachDistance{0.15};
 std::mutex mutex;
 bool magnetEnabled{false};
 Entity activeJoint{kNullEntity};
+Entity pendingJoint{kNullEntity};
 Entity carriedModel{kNullEntity};
 int publishCounter{0};
 


### PR DESCRIPTION
## Description

Fixes an issue where the drone gripper could not reliably reattach a package after a reset.

## Changes

- Properly detach the existing joint when the gripper is reset.
- Track pending joint removal until it is processed by the Entity Component Manager.
- Prevent the old joint from interfering with a new attachment.

## Testing

- Tested the Package Delivery exercise locally.
- Verified that the final diff contains only the intended changes.